### PR TITLE
Add DELETE endpoint for a specific record in HelpRequest table.

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -1,0 +1,76 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import java.time.LocalDateTime;
+
+@Tag(name = "HelpRequest")
+@RequestMapping("/api/helprequest")
+@RestController
+@Slf4j
+public class HelpRequestController {
+    @Autowired
+    HelpRequestRepository helpRequestRepository;
+
+    @Operation(summary= "List all help requests")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<HelpRequest> allHelpRequests() {
+        Iterable<HelpRequest> helpRequests = helpRequestRepository.findAll();
+        return helpRequests;
+    }
+
+    @Operation(summary= "Create a new help request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public HelpRequest postHelpRequest(
+            @Parameter(name="requesterEmail") @RequestParam String requesterEmail,
+            @Parameter(name="teamId") @RequestParam String teamId,
+            @Parameter(name="tableOrBreakoutRoom") @RequestParam String tableOrBreakoutRoom,
+            @Parameter(name="requestTime", description="date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("requestTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime requestTime,
+            @Parameter(name="explanation") @RequestParam String explanation,
+            @Parameter(name="solved") @RequestParam Boolean solved)
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("requestTime={}", requestTime);
+
+        HelpRequest helpRequest = new HelpRequest();
+        helpRequest.setRequesterEmail(requesterEmail);
+        helpRequest.setTeamId(teamId);
+        helpRequest.setTableOrBreakoutRoom(tableOrBreakoutRoom);
+        helpRequest.setRequestTime(requestTime);
+        helpRequest.setExplanation(explanation);
+        helpRequest.setSolved(solved);
+
+        HelpRequest savedHelpRequest = helpRequestRepository.save(helpRequest);
+
+        return savedHelpRequest;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -32,7 +32,7 @@ import java.time.LocalDateTime;
 @RequestMapping("/api/helprequest")
 @RestController
 @Slf4j
-public class HelpRequestController {
+public class HelpRequestController extends ApiController{
     @Autowired
     HelpRequestRepository helpRequestRepository;
 
@@ -72,5 +72,16 @@ public class HelpRequestController {
         HelpRequest savedHelpRequest = helpRequestRepository.save(helpRequest);
 
         return savedHelpRequest;
+    }
+
+    @Operation(summary= "Get a single help request")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public HelpRequest getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        HelpRequest helpRequest = helpRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+        return helpRequest;
     }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -84,4 +84,16 @@ public class HelpRequestController extends ApiController{
 
         return helpRequest;
     }
+
+    @Operation(summary= "Delete a HelpRequest")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteHelpRequest(
+            @Parameter(name="id") @RequestParam Long id) {
+        HelpRequest helpRequest = helpRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+        helpRequestRepository.delete(helpRequest);
+        return genericMessage("HelpRequest with id %s deleted".formatted(id));
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDatesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDatesController.java
@@ -50,7 +50,7 @@ public class UCSBDatesController extends ApiController {
     public UCSBDate postUCSBDate(
             @Parameter(name="quarterYYYYQ") @RequestParam String quarterYYYYQ,
             @Parameter(name="name") @RequestParam String name,
-            @Parameter(name="date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("localDateTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime localDateTime)
+            @Parameter(name="localDateTime", description="date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("localDateTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime localDateTime)
             throws JsonProcessingException {
 
         // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -60,7 +60,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
 
     @WithMockUser(roles = { "USER" })
     @Test
-    public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+    public void logged_in_user_can_get_all_helprequest() throws Exception {
 
             // arrange
             LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
@@ -119,7 +119,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
 
     @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
-    public void an_admin_user_can_post_a_new_ucsbdate() throws Exception {
+    public void an_admin_user_can_post_a_new_helprequest() throws Exception {
             // arrange
 
             LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
@@ -210,7 +210,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
 
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
-        public void admin_can_delete_a_date() throws Exception {
+        public void admin_can_delete_a_helprequest() throws Exception {
                 // arrange
 
                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
@@ -242,7 +242,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
         
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
-        public void admin_tries_to_delete_non_existant_ucsbdate_and_gets_right_error_message()
+        public void admin_tries_to_delete_non_existant_helprequest_and_gets_right_error_message()
                         throws Exception {
                 // arrange
 

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -80,7 +80,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                             .requesterEmail("test2@gmail.com")
                             .teamId("w24-5pm-4")
                             .tableOrBreakoutRoom("2")
-                            .requestTime(ldt1)
+                            .requestTime(ldt2)
                             .explanation("test2")
                             .solved(false)
                             .build();
@@ -204,5 +204,59 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 Map<String, Object> json = responseToJson(response);
                 assertEquals("EntityNotFoundException", json.get("type"));
                 assertEquals("HelpRequest with id 7 not found", json.get("message"));
+        }
+
+        // Tests for DELETE /api/ucsbdates?id=... 
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_date() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                HelpRequest helpRequest = HelpRequest.builder()
+                            .requesterEmail("test5@gmail.com")
+                            .teamId("w24-5pm-4")
+                            .tableOrBreakoutRoom("5")
+                            .requestTime(ldt1)
+                            .explanation("test5")
+                            .solved(true)
+                            .build();
+
+                when(helpRequestRepository.findById(eq(15L))).thenReturn(Optional.of(helpRequest));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/helprequest?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(helpRequestRepository, times(1)).findById(15L);
+                verify(helpRequestRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("HelpRequest with id 15 deleted", json.get("message"));
+        }
+        
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_ucsbdate_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(helpRequestRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/helprequest?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(helpRequestRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("HelpRequest with id 15 not found", json.get("message"));
         }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -147,4 +147,62 @@ public class HelpRequestControllerTests extends ControllerTestCase {
             String responseString = response.getResponse().getContentAsString();
             assertEquals(expectedJson, responseString);
     }
+
+     // Tests for GET /api/helprequest?id=...
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/helprequest?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+                LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                HelpRequest helpRequest = HelpRequest.builder()
+                            .requesterEmail("test3@gmail.com")
+                            .teamId("w24-5pm-4")
+                            .tableOrBreakoutRoom("3")
+                            .requestTime(ldt)
+                            .explanation("test3")
+                            .solved(true)
+                            .build();
+
+                when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.of(helpRequest));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/helprequest?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(helpRequestRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(helpRequest);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/helprequest?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(helpRequestRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("HelpRequest with id 7 not found", json.get("message"));
+        }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -1,0 +1,150 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = HelpRequestController.class)
+@Import(TestConfig.class)
+public class HelpRequestControllerTests extends ControllerTestCase {
+    
+    @MockBean
+    HelpRequestRepository helpRequestRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    // Tests for GET /api/helprequest/all
+        
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/helprequest/all"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/helprequest/all"))
+                            .andExpect(status().is(200)); // logged
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+
+            // arrange
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            HelpRequest helpRequest1 = HelpRequest.builder()
+                            .requesterEmail("test1@gmail.com")
+                            .teamId("w24-5pm-4")
+                            .tableOrBreakoutRoom("1")
+                            .requestTime(ldt1)
+                            .explanation("test1")
+                            .solved(false)
+                            .build();
+
+            LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
+
+            HelpRequest helpRequest2 = HelpRequest.builder()
+                            .requesterEmail("test2@gmail.com")
+                            .teamId("w24-5pm-4")
+                            .tableOrBreakoutRoom("2")
+                            .requestTime(ldt1)
+                            .explanation("test2")
+                            .solved(false)
+                            .build();
+
+            ArrayList<HelpRequest> expectedRequests = new ArrayList<>();
+            expectedRequests.addAll(Arrays.asList(helpRequest1, helpRequest2));
+
+            when(helpRequestRepository.findAll()).thenReturn(expectedRequests);
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/helprequest/all"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(helpRequestRepository, times(1)).findAll();
+            String expectedJson = mapper.writeValueAsString(expectedRequests);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    // Tests for POST /api/helprequest/post...
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/helprequest/post"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/helprequest/post"))
+                            .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_ucsbdate() throws Exception {
+            // arrange
+
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            HelpRequest helpRequest1 = HelpRequest.builder()
+                            .requesterEmail("test3@gmail.com")
+                            .teamId("w24-5pm-4")
+                            .tableOrBreakoutRoom("3")
+                            .requestTime(ldt1)
+                            .explanation("test3")
+                            .solved(true)
+                            .build();
+
+            when(helpRequestRepository.save(eq(helpRequest1))).thenReturn(helpRequest1);
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            post("/api/helprequest/post?requesterEmail=test3@gmail.com&teamId=w24-5pm-4&tableOrBreakoutRoom=3&requestTime=2022-01-03T00:00:00&explanation=test3&solved=true")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(helpRequestRepository, times(1)).save(helpRequest1);
+            String expectedJson = mapper.writeValueAsString(helpRequest1);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+}


### PR DESCRIPTION
Added the feature (and its corresponding tests) to delete a specific element in the HelpRequest database from an id.

Closes #36  