### PR TITLE
Add PUT (edit) endpoint for a single record in HelpRequest table (Completed HelpRequest)

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -28,7 +28,7 @@ import javax.validation.Valid;
 import java.time.LocalDateTime;
 
 @Tag(name = "HelpRequest")
-@RequestMapping("/api/HelpRequest")
+@RequestMapping("/api/helprequest")
 @RestController
 @Slf4j
 public class HelpRequestController extends ApiController{
@@ -84,7 +84,7 @@ public class HelpRequestController extends ApiController{
         return helpRequest;
     }
 
-    @Operation(summary= "Delete a HelpRequest")
+    @Operation(summary= "Delete a help request")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @DeleteMapping("")
     public Object deleteHelpRequest(

--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -28,7 +28,7 @@ import javax.validation.Valid;
 import java.time.LocalDateTime;
 
 @Tag(name = "HelpRequest")
-@RequestMapping("/api/helprequest")
+@RequestMapping("/api/HelpRequest")
 @RestController
 @Slf4j
 public class HelpRequestController extends ApiController{

--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -1,7 +1,6 @@
 package edu.ucsb.cs156.example.controllers;
 
 import edu.ucsb.cs156.example.entities.HelpRequest;
-import edu.ucsb.cs156.example.entities.UCSBDate;
 import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
 
@@ -95,5 +94,27 @@ public class HelpRequestController extends ApiController{
 
         helpRequestRepository.delete(helpRequest);
         return genericMessage("HelpRequest with id %s deleted".formatted(id));
+    }
+
+    @Operation(summary= "Update a single help request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public HelpRequest updateHelpRequest(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid HelpRequest incoming) {
+
+        HelpRequest helpRequest = helpRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+            helpRequest.setRequesterEmail(incoming.getRequesterEmail());
+            helpRequest.setTeamId(incoming.getTeamId());
+            helpRequest.setTableOrBreakoutRoom(incoming.getTableOrBreakoutRoom());
+            helpRequest.setRequestTime(incoming.getRequestTime());
+            helpRequest.setExplanation(incoming.getExplanation());
+            helpRequest.setSolved(incoming.getSolved());
+
+        helpRequestRepository.save(helpRequest);
+
+        return helpRequest;
     }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -42,18 +42,18 @@ public class HelpRequestControllerTests extends ControllerTestCase {
         @MockBean
         UserRepository userRepository;
 
-        // Tests for GET /api/helprequest/all
+        // Tests for GET /api/HelpRequest/all
                 
         @Test
         public void logged_out_users_cannot_get_all() throws Exception {
-                mockMvc.perform(get("/api/helprequest/all"))
+                mockMvc.perform(get("/api/HelpRequest/all"))
                                 .andExpect(status().is(403)); // logged out users can't get all
         }
 
         @WithMockUser(roles = { "USER" })
         @Test
         public void logged_in_users_can_get_all() throws Exception {
-                mockMvc.perform(get("/api/helprequest/all"))
+                mockMvc.perform(get("/api/HelpRequest/all"))
                                 .andExpect(status().is(200)); // logged
         }
 
@@ -90,7 +90,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 when(helpRequestRepository.findAll()).thenReturn(expectedRequests);
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/helprequest/all"))
+                MvcResult response = mockMvc.perform(get("/api/HelpRequest/all"))
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert
@@ -101,18 +101,18 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 assertEquals(expectedJson, responseString);
         }
 
-        // Tests for POST /api/helprequest/post...
+        // Tests for POST /api/HelpRequest/post...
 
         @Test
         public void logged_out_users_cannot_post() throws Exception {
-                mockMvc.perform(post("/api/helprequest/post"))
+                mockMvc.perform(post("/api/HelpRequest/post"))
                                 .andExpect(status().is(403));
         }
 
         @WithMockUser(roles = { "USER" })
         @Test
         public void logged_in_regular_users_cannot_post() throws Exception {
-                mockMvc.perform(post("/api/helprequest/post"))
+                mockMvc.perform(post("/api/HelpRequest/post"))
                                 .andExpect(status().is(403)); // only admins can post
         }
 
@@ -136,7 +136,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                post("/api/helprequest/post?requesterEmail=test3@gmail.com&teamId=w24-5pm-4&tableOrBreakoutRoom=3&requestTime=2022-01-03T00:00:00&explanation=test3&solved=true")
+                                post("/api/HelpRequest/post?requesterEmail=test3@gmail.com&teamId=w24-5pm-4&tableOrBreakoutRoom=3&requestTime=2022-01-03T00:00:00&explanation=test3&solved=true")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
@@ -147,11 +147,11 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 assertEquals(expectedJson, responseString);
         }
 
-        // Tests for GET /api/helprequest?id=...
+        // Tests for GET /api/HelpRequest?id=...
 
         @Test
         public void logged_out_users_cannot_get_by_id() throws Exception {
-                mockMvc.perform(get("/api/helprequest?id=7"))
+                mockMvc.perform(get("/api/HelpRequest?id=7"))
                                 .andExpect(status().is(403)); // logged out users can't get by id
         }
 
@@ -174,7 +174,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.of(helpRequest));
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/helprequest?id=7"))
+                MvcResult response = mockMvc.perform(get("/api/HelpRequest?id=7"))
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert
@@ -194,7 +194,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/helprequest?id=7"))
+                MvcResult response = mockMvc.perform(get("/api/HelpRequest?id=7"))
                                 .andExpect(status().isNotFound()).andReturn();
 
                 // assert
@@ -205,7 +205,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 assertEquals("HelpRequest with id 7 not found", json.get("message"));
         }
 
-        // Tests for DELETE /api/helprequest?id=... 
+        // Tests for DELETE /api/HelpRequest?id=... 
 
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
@@ -227,7 +227,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                delete("/api/helprequest?id=15")
+                                delete("/api/HelpRequest?id=15")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
@@ -249,7 +249,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                delete("/api/helprequest?id=15")
+                                delete("/api/HelpRequest?id=15")
                                                 .with(csrf()))
                                 .andExpect(status().isNotFound()).andReturn();
 
@@ -259,7 +259,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 assertEquals("HelpRequest with id 15 not found", json.get("message"));
         }
 
-        // Tests for PUT /api/helprequest?id=... 
+        // Tests for PUT /api/HelpRequest?id=... 
 
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
@@ -293,7 +293,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                put("/api/helprequest?id=67")
+                                put("/api/HelpRequest?id=67")
                                                 .contentType(MediaType.APPLICATION_JSON)
                                                 .characterEncoding("utf-8")
                                                 .content(requestBody)
@@ -330,7 +330,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                put("/api/helprequest?id=67")
+                                put("/api/HelpRequest?id=67")
                                                 .contentType(MediaType.APPLICATION_JSON)
                                                 .characterEncoding("utf-8")
                                                 .content(requestBody)

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -42,18 +42,18 @@ public class HelpRequestControllerTests extends ControllerTestCase {
         @MockBean
         UserRepository userRepository;
 
-        // Tests for GET /api/HelpRequest/all
+        // Tests for GET /api/helprequest/all
                 
         @Test
         public void logged_out_users_cannot_get_all() throws Exception {
-                mockMvc.perform(get("/api/HelpRequest/all"))
+                mockMvc.perform(get("/api/helprequest/all"))
                                 .andExpect(status().is(403)); // logged out users can't get all
         }
 
         @WithMockUser(roles = { "USER" })
         @Test
         public void logged_in_users_can_get_all() throws Exception {
-                mockMvc.perform(get("/api/HelpRequest/all"))
+                mockMvc.perform(get("/api/helprequest/all"))
                                 .andExpect(status().is(200)); // logged
         }
 
@@ -90,7 +90,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 when(helpRequestRepository.findAll()).thenReturn(expectedRequests);
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/HelpRequest/all"))
+                MvcResult response = mockMvc.perform(get("/api/helprequest/all"))
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert
@@ -101,18 +101,18 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 assertEquals(expectedJson, responseString);
         }
 
-        // Tests for POST /api/HelpRequest/post...
+        // Tests for POST /api/helprequest/post...
 
         @Test
         public void logged_out_users_cannot_post() throws Exception {
-                mockMvc.perform(post("/api/HelpRequest/post"))
+                mockMvc.perform(post("/api/helprequest/post"))
                                 .andExpect(status().is(403));
         }
 
         @WithMockUser(roles = { "USER" })
         @Test
         public void logged_in_regular_users_cannot_post() throws Exception {
-                mockMvc.perform(post("/api/HelpRequest/post"))
+                mockMvc.perform(post("/api/helprequest/post"))
                                 .andExpect(status().is(403)); // only admins can post
         }
 
@@ -136,7 +136,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                post("/api/HelpRequest/post?requesterEmail=test3@gmail.com&teamId=w24-5pm-4&tableOrBreakoutRoom=3&requestTime=2022-01-03T00:00:00&explanation=test3&solved=true")
+                                post("/api/helprequest/post?requesterEmail=test3@gmail.com&teamId=w24-5pm-4&tableOrBreakoutRoom=3&requestTime=2022-01-03T00:00:00&explanation=test3&solved=true")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
@@ -147,11 +147,11 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 assertEquals(expectedJson, responseString);
         }
 
-        // Tests for GET /api/HelpRequest?id=...
+        // Tests for GET /api/helprequest?id=...
 
         @Test
         public void logged_out_users_cannot_get_by_id() throws Exception {
-                mockMvc.perform(get("/api/HelpRequest?id=7"))
+                mockMvc.perform(get("/api/helprequest?id=7"))
                                 .andExpect(status().is(403)); // logged out users can't get by id
         }
 
@@ -174,7 +174,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.of(helpRequest));
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/HelpRequest?id=7"))
+                MvcResult response = mockMvc.perform(get("/api/helprequest?id=7"))
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert
@@ -194,7 +194,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/HelpRequest?id=7"))
+                MvcResult response = mockMvc.perform(get("/api/helprequest?id=7"))
                                 .andExpect(status().isNotFound()).andReturn();
 
                 // assert
@@ -205,7 +205,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 assertEquals("HelpRequest with id 7 not found", json.get("message"));
         }
 
-        // Tests for DELETE /api/HelpRequest?id=... 
+        // Tests for DELETE /api/helprequest?id=... 
 
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
@@ -227,7 +227,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                delete("/api/HelpRequest?id=15")
+                                delete("/api/helprequest?id=15")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
@@ -249,7 +249,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                delete("/api/HelpRequest?id=15")
+                                delete("/api/helprequest?id=15")
                                                 .with(csrf()))
                                 .andExpect(status().isNotFound()).andReturn();
 
@@ -293,7 +293,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                put("/api/HelpRequest?id=67")
+                                put("/api/helprequest?id=67")
                                                 .contentType(MediaType.APPLICATION_JSON)
                                                 .characterEncoding("utf-8")
                                                 .content(requestBody)
@@ -330,7 +330,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                put("/api/HelpRequest?id=67")
+                                put("/api/helprequest?id=67")
                                                 .contentType(MediaType.APPLICATION_JSON)
                                                 .characterEncoding("utf-8")
                                                 .content(requestBody)

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -4,7 +4,6 @@ import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
 import edu.ucsb.cs156.example.ControllerTestCase;
 import edu.ucsb.cs156.example.entities.HelpRequest;
-import edu.ucsb.cs156.example.entities.UCSBDate;
 import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
 
 import java.util.ArrayList;
@@ -37,118 +36,118 @@ import static org.mockito.Mockito.when;
 @Import(TestConfig.class)
 public class HelpRequestControllerTests extends ControllerTestCase {
     
-    @MockBean
-    HelpRequestRepository helpRequestRepository;
+        @MockBean
+        HelpRequestRepository helpRequestRepository;
 
-    @MockBean
-    UserRepository userRepository;
+        @MockBean
+        UserRepository userRepository;
 
-    // Tests for GET /api/helprequest/all
-        
-    @Test
-    public void logged_out_users_cannot_get_all() throws Exception {
-            mockMvc.perform(get("/api/helprequest/all"))
-                            .andExpect(status().is(403)); // logged out users can't get all
-    }
+        // Tests for GET /api/helprequest/all
+                
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/helprequest/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
 
-    @WithMockUser(roles = { "USER" })
-    @Test
-    public void logged_in_users_can_get_all() throws Exception {
-            mockMvc.perform(get("/api/helprequest/all"))
-                            .andExpect(status().is(200)); // logged
-    }
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/helprequest/all"))
+                                .andExpect(status().is(200)); // logged
+        }
 
-    @WithMockUser(roles = { "USER" })
-    @Test
-    public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_helprequest() throws Exception {
 
-            // arrange
-            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+                // arrange
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
 
-            HelpRequest helpRequest1 = HelpRequest.builder()
-                            .requesterEmail("test1@gmail.com")
-                            .teamId("w24-5pm-4")
-                            .tableOrBreakoutRoom("1")
-                            .requestTime(ldt1)
-                            .explanation("test1")
-                            .solved(false)
-                            .build();
+                HelpRequest helpRequest1 = HelpRequest.builder()
+                                .requesterEmail("test1@gmail.com")
+                                .teamId("w24-5pm-4")
+                                .tableOrBreakoutRoom("1")
+                                .requestTime(ldt1)
+                                .explanation("test1")
+                                .solved(false)
+                                .build();
 
-            LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
+                LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
 
-            HelpRequest helpRequest2 = HelpRequest.builder()
-                            .requesterEmail("test2@gmail.com")
-                            .teamId("w24-5pm-4")
-                            .tableOrBreakoutRoom("2")
-                            .requestTime(ldt2)
-                            .explanation("test2")
-                            .solved(false)
-                            .build();
+                HelpRequest helpRequest2 = HelpRequest.builder()
+                                .requesterEmail("test2@gmail.com")
+                                .teamId("w24-5pm-4")
+                                .tableOrBreakoutRoom("2")
+                                .requestTime(ldt2)
+                                .explanation("test2")
+                                .solved(false)
+                                .build();
 
-            ArrayList<HelpRequest> expectedRequests = new ArrayList<>();
-            expectedRequests.addAll(Arrays.asList(helpRequest1, helpRequest2));
+                ArrayList<HelpRequest> expectedRequests = new ArrayList<>();
+                expectedRequests.addAll(Arrays.asList(helpRequest1, helpRequest2));
 
-            when(helpRequestRepository.findAll()).thenReturn(expectedRequests);
+                when(helpRequestRepository.findAll()).thenReturn(expectedRequests);
 
-            // act
-            MvcResult response = mockMvc.perform(get("/api/helprequest/all"))
-                            .andExpect(status().isOk()).andReturn();
+                // act
+                MvcResult response = mockMvc.perform(get("/api/helprequest/all"))
+                                .andExpect(status().isOk()).andReturn();
 
-            // assert
+                // assert
 
-            verify(helpRequestRepository, times(1)).findAll();
-            String expectedJson = mapper.writeValueAsString(expectedRequests);
-            String responseString = response.getResponse().getContentAsString();
-            assertEquals(expectedJson, responseString);
-    }
+                verify(helpRequestRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedRequests);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
 
-    // Tests for POST /api/helprequest/post...
+        // Tests for POST /api/helprequest/post...
 
-    @Test
-    public void logged_out_users_cannot_post() throws Exception {
-            mockMvc.perform(post("/api/helprequest/post"))
-                            .andExpect(status().is(403));
-    }
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/helprequest/post"))
+                                .andExpect(status().is(403));
+        }
 
-    @WithMockUser(roles = { "USER" })
-    @Test
-    public void logged_in_regular_users_cannot_post() throws Exception {
-            mockMvc.perform(post("/api/helprequest/post"))
-                            .andExpect(status().is(403)); // only admins can post
-    }
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/helprequest/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
 
-    @WithMockUser(roles = { "ADMIN", "USER" })
-    @Test
-    public void an_admin_user_can_post_a_new_ucsbdate() throws Exception {
-            // arrange
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_helprequest() throws Exception {
+                // arrange
 
-            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
 
-            HelpRequest helpRequest1 = HelpRequest.builder()
-                            .requesterEmail("test3@gmail.com")
-                            .teamId("w24-5pm-4")
-                            .tableOrBreakoutRoom("3")
-                            .requestTime(ldt1)
-                            .explanation("test3")
-                            .solved(true)
-                            .build();
+                HelpRequest helpRequest1 = HelpRequest.builder()
+                                .requesterEmail("test3@gmail.com")
+                                .teamId("w24-5pm-4")
+                                .tableOrBreakoutRoom("3")
+                                .requestTime(ldt1)
+                                .explanation("test3")
+                                .solved(true)
+                                .build();
 
-            when(helpRequestRepository.save(eq(helpRequest1))).thenReturn(helpRequest1);
+                when(helpRequestRepository.save(eq(helpRequest1))).thenReturn(helpRequest1);
 
-            // act
-            MvcResult response = mockMvc.perform(
-                            post("/api/helprequest/post?requesterEmail=test3@gmail.com&teamId=w24-5pm-4&tableOrBreakoutRoom=3&requestTime=2022-01-03T00:00:00&explanation=test3&solved=true")
-                                            .with(csrf()))
-                            .andExpect(status().isOk()).andReturn();
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/helprequest/post?requesterEmail=test3@gmail.com&teamId=w24-5pm-4&tableOrBreakoutRoom=3&requestTime=2022-01-03T00:00:00&explanation=test3&solved=true")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
 
-            // assert
-            verify(helpRequestRepository, times(1)).save(helpRequest1);
-            String expectedJson = mapper.writeValueAsString(helpRequest1);
-            String responseString = response.getResponse().getContentAsString();
-            assertEquals(expectedJson, responseString);
-    }
+                // assert
+                verify(helpRequestRepository, times(1)).save(helpRequest1);
+                String expectedJson = mapper.writeValueAsString(helpRequest1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
 
-     // Tests for GET /api/helprequest?id=...
+        // Tests for GET /api/helprequest?id=...
 
         @Test
         public void logged_out_users_cannot_get_by_id() throws Exception {
@@ -164,13 +163,13 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
 
                 HelpRequest helpRequest = HelpRequest.builder()
-                            .requesterEmail("test3@gmail.com")
-                            .teamId("w24-5pm-4")
-                            .tableOrBreakoutRoom("3")
-                            .requestTime(ldt)
-                            .explanation("test3")
-                            .solved(true)
-                            .build();
+                                .requesterEmail("test3@gmail.com")
+                                .teamId("w24-5pm-4")
+                                .tableOrBreakoutRoom("3")
+                                .requestTime(ldt)
+                                .explanation("test3")
+                                .solved(true)
+                                .build();
 
                 when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.of(helpRequest));
 
@@ -206,23 +205,23 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 assertEquals("HelpRequest with id 7 not found", json.get("message"));
         }
 
-        // Tests for DELETE /api/ucsbdates?id=... 
+        // Tests for DELETE /api/helprequest?id=... 
 
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
-        public void admin_can_delete_a_date() throws Exception {
+        public void admin_can_delete_a_helprequest() throws Exception {
                 // arrange
 
                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
 
                 HelpRequest helpRequest = HelpRequest.builder()
-                            .requesterEmail("test5@gmail.com")
-                            .teamId("w24-5pm-4")
-                            .tableOrBreakoutRoom("5")
-                            .requestTime(ldt1)
-                            .explanation("test5")
-                            .solved(true)
-                            .build();
+                                .requesterEmail("test5@gmail.com")
+                                .teamId("w24-5pm-4")
+                                .tableOrBreakoutRoom("5")
+                                .requestTime(ldt1)
+                                .explanation("test5")
+                                .solved(true)
+                                .build();
 
                 when(helpRequestRepository.findById(eq(15L))).thenReturn(Optional.of(helpRequest));
 
@@ -239,10 +238,10 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 Map<String, Object> json = responseToJson(response);
                 assertEquals("HelpRequest with id 15 deleted", json.get("message"));
         }
-        
+
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
-        public void admin_tries_to_delete_non_existant_ucsbdate_and_gets_right_error_message()
+        public void admin_tries_to_delete_non_existant_helprequest_and_gets_right_error_message()
                         throws Exception {
                 // arrange
 
@@ -258,5 +257,89 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 verify(helpRequestRepository, times(1)).findById(15L);
                 Map<String, Object> json = responseToJson(response);
                 assertEquals("HelpRequest with id 15 not found", json.get("message"));
+        }
+
+        // Tests for PUT /api/helprequest?id=... 
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_helprequest() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+                LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+                HelpRequest helpRequestOrig = HelpRequest.builder()
+                                .requesterEmail("test6@gmail.com")
+                                .teamId("w24-5pm-4")
+                                .tableOrBreakoutRoom("6")
+                                .requestTime(ldt1)
+                                .explanation("test6")
+                                .solved(true)
+                                .build();
+
+                HelpRequest helpRequestEdited = HelpRequest.builder()
+                                .requesterEmail("test7@gmail.com")
+                                .teamId("w24-5pm-2")
+                                .tableOrBreakoutRoom("7")
+                                .requestTime(ldt2)
+                                .explanation("test7")
+                                .solved(false)
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(helpRequestEdited);
+
+                when(helpRequestRepository.findById(eq(67L))).thenReturn(Optional.of(helpRequestOrig));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/helprequest?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(helpRequestRepository, times(1)).findById(67L);
+                verify(helpRequestRepository, times(1)).save(helpRequestEdited); // should be saved with correct user
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_helprequest_that_does_not_exist() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                HelpRequest helpRequestEdited2 = HelpRequest.builder()
+                                .requesterEmail("test8@gmail.com")
+                                .teamId("w24-5pm-4")
+                                .tableOrBreakoutRoom("8")
+                                .requestTime(ldt1)
+                                .explanation("test8")
+                                .solved(true)
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(helpRequestEdited2);
+
+                when(helpRequestRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/helprequest?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(helpRequestRepository, times(1)).findById(67L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("HelpRequest with id 67 not found", json.get("message"));
         }
 }


### PR DESCRIPTION
Added the feature (and its corresponding tests) to edit a specific element in the HelpRequest database from an id.
Also retroactively changed some variable/function names to match HelpRequest.
This is the last feature of HelpRequest for team02.
Deployed to dokku at: https://team02-colefoster08-dev.dokku-08.cs.ucsb.edu

Closes #35 